### PR TITLE
add git install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gentoo/stage3-amd64:latest
 RUN emerge --sync
 RUN emerge =sys-devel/gcc-4.5.4 && rm -rf /var/tmp/protage/*
 RUN gcc-config x86_64-pc-linux-gnu-4.5.4 && env-update && source /etc/profile
-RUN emerge eix vim net-misc/curl && rm -rf /var/tmp/portage/*
+RUN emerge eix vim net-misc/curl dev-vcs/git && rm -rf /var/tmp/portage/*
 
 ## Ruby
 ADD keyword /etc/portage/package.accept_keywords/ruby


### PR DESCRIPTION
If you specify a git repository in Gemfile, it will become an error, such as:

```
You need to install git to be able to use gems from git repositories. For help
installing git, please refer to GitHub's tutorial at
https://help.github.com/articles/set-up-git
```

Perhaps whether need to install the git I think.

I'm sorry if I misunderstood.
